### PR TITLE
added deserialization constructor

### DIFF
--- a/resource-server/src/main/java/io/smalldata/ohmageomh/dsu/domain/DataPointMedia.java
+++ b/resource-server/src/main/java/io/smalldata/ohmageomh/dsu/domain/DataPointMedia.java
@@ -1,7 +1,8 @@
 package io.smalldata.ohmageomh.dsu.domain;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.openmhealth.schema.domain.omh.DataPoint;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.annotation.Transient;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -37,8 +38,9 @@ public class DataPointMedia {
     /**
      * The {@link InputStream} that is connected to the data.
      */
-    @Transient
-    private final InputStream stream;
+    @Transient // do not store this field
+    @JsonIgnore // do not serialize this field
+    private InputStream stream;
     /**
      * The size, in bytes, of the data.
      */
@@ -49,6 +51,15 @@ public class DataPointMedia {
     private final String contentType;
     private final String userId;
 
+    @PersistenceConstructor
+    public DataPointMedia(String id, String mediaId, String dataPointId, long size, String contentType, String userId){
+        this.id = id;
+        this.mediaId = mediaId;
+        this.dataPointId = dataPointId;
+        this.size = size;
+        this.contentType = contentType;
+        this.userId = userId;
+    }
     /**
      * Creates a new Media object from a {@link org.springframework.web.multipart.MultipartFile} object.
      *
@@ -64,7 +75,7 @@ public class DataPointMedia {
      * @see #generateUuid()
      */
     public DataPointMedia(final DataPoint datapoint, final MultipartFile media)
-        throws IllegalArgumentException {
+            throws IllegalArgumentException {
 
         // Validate the input.
         if(datapoint == null) {
@@ -83,9 +94,9 @@ public class DataPointMedia {
         }
         catch(IOException e) {
             throw
-                new IllegalArgumentException(
-                    "Could not connect to the media.",
-                    e);
+                    new IllegalArgumentException(
+                            "Could not connect to the media.",
+                            e);
         }
         mediaId = media.getOriginalFilename();
         size = media.getSize();


### PR DESCRIPTION
Added deserialization constructor so that the data point response will be like this (see the *media* field):

```json
{
    "header": {
        "id": "foo11",
        "creation_date_time": "2013-02-05T07:25:00Z",
        "acquisition_provenance": {
            "source_name": "RunKeeper",
            "modality": "sensed"
        },
        "user_id": "testUser",
        "schema_id": {
            "namespace": "omh",
            "name": "physical-activity",
            "version": "1.0"
        },
        "media": [
            {
                "id": "6babad1a-9dd7-4b36-ae6c-85c5ead9bc00",
                "media_id": "out",
                "data_point_id": "foo11",
                "size": 2045627,
                "content_type": "application/octet-stream"
            }
        ]
    },
    "body": {
        "activity_name": "walking",
        "distance": {
            "value": 1.5,
            "unit": "mi"
        },
        "reported_activity_intensity": "moderate",
        "effective_time_frame": {
            "time_interval": {
                "date": "2013-02-05",
                "part_of_day": "morning"
            }
        }
    }
}
```